### PR TITLE
feature: Add type "hidden" for <.form_field> to avoid warnings

### DIFF
--- a/lib/phoenix_ui_components/form.ex
+++ b/lib/phoenix_ui_components/form.ex
@@ -97,7 +97,8 @@ defmodule PhoenixUiComponents.Form do
       "select",
       "file",
       "date_select",
-      "date"
+      "date",
+      "hidden"
     ],
     default: "text"
   )


### PR DESCRIPTION
Here is a warning from Simulators:
```
    warning: attribute "type" in component Web.Components.FormField.form_field/1 must be one of ["text", "email", "password", "number", "date", "month", "week", "time", "datetime-local", "search", "tel", "url", "select", "textarea"], got: "hidden"
    │
 79 │           <.form_field type="hidden" field={@form[:location_id]} value={@location_id} />
    │           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    │
    └─ lib/foerst_dashboard_web/live/locations/assign_simulator_modal.ex:79: (file)
```

We need to add this "hidden" to avoid warnings like that